### PR TITLE
Do imports to match what happens in GremlinServer/Console

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,17 +104,19 @@
             <artifactId>jupyter-groovy-kernel</artifactId>
             <version>${kernel.version}</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.codehaus.groovy/groovy-all -->
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>2.5.8</version>
-            <type>pom</type>
-        </dependency>
-        <!-- TODO: Do I need a gremlin dependency? //-->
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-core</artifactId>
+            <version>${tinkerpop.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tinkerpop</groupId>
+            <artifactId>gremlin-driver</artifactId>
+            <version>${tinkerpop.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tinkerpop</groupId>
+            <artifactId>gremlin-groovy</artifactId>
             <version>${tinkerpop.version}</version>
         </dependency>
         <dependency>
@@ -131,16 +133,6 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
             <version>1.1.3</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-client</artifactId>
-            <version>1.19</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.jersey.contribs</groupId>
-            <artifactId>jersey-multipart</artifactId>
-            <version>1.17.1</version>
         </dependency>
     </dependencies>
     <!-- from https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-Maven-plugin //-->

--- a/src/main/groovy/org/gdbassett/jupyter/gremlin/GremlinContext.groovy
+++ b/src/main/groovy/org/gdbassett/jupyter/gremlin/GremlinContext.groovy
@@ -17,6 +17,38 @@
 
 package org.gdbassett.jupyter.gremlin
 
+import org.apache.tinkerpop.gremlin.driver.Client
+import org.apache.tinkerpop.gremlin.driver.Cluster
+import org.apache.tinkerpop.gremlin.driver.Host
+import org.apache.tinkerpop.gremlin.driver.LoadBalancingStrategy
+import org.apache.tinkerpop.gremlin.driver.MessageSerializer
+import org.apache.tinkerpop.gremlin.driver.Result
+import org.apache.tinkerpop.gremlin.driver.ResultSet
+import org.apache.tinkerpop.gremlin.driver.Tokens
+import org.apache.tinkerpop.gremlin.driver.exception.ConnectionException
+import org.apache.tinkerpop.gremlin.driver.exception.ResponseException
+import org.apache.tinkerpop.gremlin.driver.message.RequestMessage
+import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage
+import org.apache.tinkerpop.gremlin.driver.message.ResponseResult
+import org.apache.tinkerpop.gremlin.driver.message.ResponseStatus
+import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode
+import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection
+import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteTraversal
+import org.apache.tinkerpop.gremlin.driver.ser.GraphBinaryMessageSerializerV1
+import org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0
+import org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV2d0
+import org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0
+import org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV2d0
+import org.apache.tinkerpop.gremlin.driver.ser.GryoLiteMessageSerializerV1d0
+import org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0
+import org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0
+import org.apache.tinkerpop.gremlin.driver.ser.JsonBuilderGryoSerializer
+import org.apache.tinkerpop.gremlin.driver.ser.MessageTextSerializer
+import org.apache.tinkerpop.gremlin.driver.ser.SerTokens
+import org.apache.tinkerpop.gremlin.driver.ser.SerializationException
+import org.apache.tinkerpop.gremlin.driver.ser.Serializers
+import org.apache.tinkerpop.gremlin.jsr223.CoreImports
+import org.apache.tinkerpop.gremlin.jsr223.DefaultImportCustomizer
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.control.customizers.ImportCustomizer
 import org.lappsgrid.jupyter.groovy.context.DefaultGroovyContext
@@ -26,31 +58,63 @@ import org.lappsgrid.jupyter.groovy.context.DefaultGroovyContext
  */
 class GremlinContext extends DefaultGroovyContext {
 
+    private static org.apache.tinkerpop.gremlin.jsr223.ImportCustomizer coreImports = DefaultImportCustomizer.build()
+            .addClassImports(CoreImports.getClassImports())
+            .addFieldImports(CoreImports.getFieldImports())
+            .addEnumImports(CoreImports.getEnumImports())
+            .addMethodImports(CoreImports.getMethodImports()).create()
+
+    private static org.apache.tinkerpop.gremlin.jsr223.ImportCustomizer driverImports = DefaultImportCustomizer.build()
+            .addClassImports(Cluster.class,
+                    Client.class,
+                    Host.class,
+                    LoadBalancingStrategy.class,
+                    MessageSerializer.class,
+                    Result.class,
+                    ResultSet.class,
+                    Tokens.class,
+                    ConnectionException.class,
+                    ResponseException.class,
+                    RequestMessage.class,
+                    ResponseMessage.class,
+                    ResponseResult.class,
+                    ResponseStatus.class,
+                    ResponseStatusCode.class,
+                    GraphSONMessageSerializerGremlinV1d0.class,
+                    GraphSONMessageSerializerGremlinV2d0.class,
+                    GraphSONMessageSerializerV1d0.class,
+                    GraphSONMessageSerializerV2d0.class,
+                    GryoLiteMessageSerializerV1d0.class,
+                    GryoMessageSerializerV1d0.class,
+                    GryoMessageSerializerV3d0.class,
+                    GraphBinaryMessageSerializerV1.class,
+                    JsonBuilderGryoSerializer.class,
+                    MessageTextSerializer.class,
+                    SerializationException.class,
+                    Serializers.class,
+                    SerTokens.class,
+                    DriverRemoteConnection.class,
+                    DriverRemoteTraversal.class).create()
+
     @Override
     CompilerConfiguration getCompilerConfiguration() {
-        ImportCustomizer customizer = new ImportCustomizer()
-        [
-            'org.apache.tinkerpop.gremlin.process.traversal.dsl.graph',
-            'org.apache.tinkerpop.gremlin.structure.util',
-            'org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph',
-            'org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection'
-        // TODO: Replace below imports with appropriate imports from Gremlin
-        /*    'org.lappsgrid.api',
-            'org.lappsgrid.core',
-            'org.lappsgrid.client',
-            'org.lappsgrid.discriminator',
-            'org.lappsgrid.serialization',
-            'org.lappsgrid.serialization.lif',
-            'org.lappsgrid.serialization.datasource',
-            'org.lappsgrid.metadata' */
-        ].each {
-            customizer.addStarImports(it)
-        }
-        // TODO: replace below line if necessary
-        //customizer.addStaticImport('org.lappsgrid.discriminator.Discriminators', 'Uri')
+        def customizers = [coreImports, driverImports]
 
-        CompilerConfiguration configuration = new CompilerConfiguration()
-        configuration.addCompilationCustomizers(customizer)
+        def imports = new ImportCustomizer()
+
+        // use same model as ImportGroovyCustomizer
+        imports.addStaticStars(org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.class.getCanonicalName())
+        for (org.apache.tinkerpop.gremlin.jsr223.ImportCustomizer customizer : customizers) {
+            customizer.getClassImports().each{ imports.addImports(it.getCanonicalName()) }
+            customizer.getMethodImports().
+                    find{ it.getDeclaringClass() != org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.class }.
+                    each{ imports.addStaticImport(it.getDeclaringClass().getCanonicalName(), it.getName()) }
+            customizer.getEnumImports().each{ imports.addStaticImport(it.getDeclaringClass().getCanonicalName(), it.name()) }
+            customizer.getFieldImports().each{ imports.addStaticImport(it.getDeclaringClass().getCanonicalName(), it.getName()) }
+        }
+
+        def configuration = new CompilerConfiguration()
+        configuration.addCompilationCustomizers(imports)
         return configuration
     }
 


### PR DESCRIPTION
The pom.xml still looks overly complicated to me and there is more streamlining to be done, but this change does get the imports to look the exact same as Gremlin Console and Server. If you could confirm that things still work after my changes here I wonder what you might think about forming this into a potential PR to TinkerPop itself. I guess we should gauge interest on the dev list but I think that this would be a neat feature especially since it's such a straightforward body of code. 